### PR TITLE
Get hit dice from first class item

### DIFF
--- a/src/dicetooltip.js
+++ b/src/dicetooltip.js
@@ -84,7 +84,7 @@ function prepareDiceTooltipEvents(html) {
 }
 
 function checkShortRestTooltip(actor) {
-  var tooltipStr = "<p><b>• Hit Die:</b> " + actor.data.items[0].data.hitDice + "</p>";
+  var tooltipStr = "<p><b>• Hit Die:</b> " + (actor.data.items.filter(it => it.type === "class").map(it => it.data.hitDice).join(", ") || "unknown") + "</p>";
   showTooltip(tooltipStr);
 }
 


### PR DESCRIPTION
Instead of assuming the first sheet item is a class (which is not always the case if a user adds spells/items to their sheet first), attempt to find all class items and display their hit dice as a comma-separated list. If there are no class items, display the text "unknown" instead.